### PR TITLE
Fixes association between items & ticket/donation

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,6 +14,6 @@ class Item < ActiveRecord::Base
   has_many :containers
   has_many :holdings
   has_many :inventories, through: :holdings
-  has_many :donations, through: :containers
-  has_many :tickets, through: :containers
+  has_many :donations, through: :containers, source: :itemizable, source_type: Donation
+  has_many :tickets, through: :containers, source: :itemizable, source_type: Ticket
 end


### PR DESCRIPTION
Missing the source properties on the `has_many` through association from
`Item` that define the source polymorphic relationship and the type of
the class for the association.
