### PR TITLE
Enables managing unicron from capistrano

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -15,5 +15,3 @@ set :format, :pretty
 
 set :linked_files, fetch(:linked_files, []).push('.env')
 set :linked_dirs, fetch(:linked_dirs, []).push('log', 'vendor/bundle', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'public/system')
-
-set :format_options, command_output: true, log_file: 'log/capistrano.log', color: :auto, truncate: :auto

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -68,8 +68,22 @@ set :pty, true
 
 
 namespace :deploy do
+  task :start do
+    on roles(:app) do
+      invoke 'unicorn:start'
+    end
+  end
+
   task :restart do
-	# run "touch #{File.join(current_path, 'tmp', 'restart.txt') }"
+    on roles(:app) do
+      invoke 'unicorn:restart'
+    end
+  end
+
+  task :stop do
+    on roles(:app) do
+      invoke 'unicron:stop'
+    end
   end
 
   after :restart, :clear_cache do


### PR DESCRIPTION
This should allow capistrano to start, stop, and restart unicorn and
integrates that into the deployment process
