### PR TITLE
Fixes #43 by validating ticket containers

### DIFF
--- a/app/admin/ticket.rb
+++ b/app/admin/ticket.rb
@@ -25,7 +25,7 @@ ActiveAdmin.register Ticket do
       @ticket = Ticket.new permitted_params[:ticket]
       inventory = @ticket.inventory
       begin
-        inventory.distribute!(@ticket)
+        inventory.distribute!(@ticket) if inventory
         if @ticket.save
           redirect_to @ticket, notice: "Successfully created new ticket"
         else
@@ -73,7 +73,7 @@ ActiveAdmin.register Ticket do
 
   form do |f|
     inputs do
-      input :partner_id, :label => 'Partner', :as => :select, :collection => Partner.all
+      input :partner, :label => 'Partner', :as => :select, :collection => Partner.all
       input :inventory, :label => 'Storage Facility', :as => :select, :collection => Inventory.all
     end
     inputs 'Items' do


### PR DESCRIPTION
This particular bug would try to generate an error message using the
item name of a container, however in this case the user never selected
an item on the form so we were calling `#name` on `nil`. This ensures
that contaners on a ticket are valid by checking for both the item and
quantity

Also found a 2nd bug where `#distribute!` would get called on inventory,
even if the user never selected an inventory on the form.
