### PR TITLE
Removes unnecessary filters from ticket index

### DIFF
--- a/app/admin/ticket.rb
+++ b/app/admin/ticket.rb
@@ -16,6 +16,11 @@ ActiveAdmin.register Ticket do
     link_to "Reclaim", reclaim_ticket_path(ticket), method: :put
   end
 
+  filter :inventory
+  filter :partner
+  filter :items
+  filter :created_at, as: :date_range
+
   permit_params :inventory_id,
     :partner_id,
     :containers_attributes => [:item_id, :quantity, :id, :_destroy]


### PR DESCRIPTION
The containers filter is pointless because containers will always be
unique and only ever belong to a specific ticket. There aren't any use
cases where a user would search for tickets by a specific container
record.

Also removes the updated_at filter since tickets will never be updated.
