### PR TITLE
Restructures form elements to match AA's styles

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -12,17 +12,17 @@ ActiveAdmin.register_page "Dashboard" do
     end
   end
 
-  sidebar :options do
-    form_for :event, { :url => dashboard_update_metrics_path } do |f|
-      div do
-        f.label :starts_at
-        f.text_field :starts_at, :as => :datepicker, :class => "datepicker hasDatetimePicker dashboardDatePicker", :value  => (default_start_date).strftime('%Y-%m-%d')
+  sidebar :filter do
+    form_for :event, url: dashboard_update_metrics_path, html: { class: "filter_form" } do |f|
+      div class: "date_range input filter_form_field filter_date_range" do
+        f.label :by_date, class: "label"
+        f.text_field :starts_at, as: :datepicker, class: "datepicker hasDatetimePicker dashboardDatePicker", size: 12, maxlength: 10, value: (default_start_date).strftime('%Y-%m-%d')
+        span "-", class: "seperator"
+        f.text_field :ends_at, as: :datepicker, class: "datepicker hasDatetimePicker dashboardDatePicker", size: 12, maxlength: 10, value: DateTime.now.strftime('%Y-%m-%d')
       end
-      div do
-        f.label :ends_at
-        f.text_field :ends_at, :as => :datepicker, :class => "datepicker hasDatetimePicker dashboardDatePicker", :value  => DateTime.now.strftime('%Y-%m-%d')
+      div class: "buttons" do
+        f.submit "Update Filter"
       end
-      f.submit "Update Date Range"
     end
   end
 
@@ -31,8 +31,8 @@ ActiveAdmin.register_page "Dashboard" do
       column do
         inventories = Inventory.all.collect { |i| i.name }
         all_items = {}
-        
-        # 
+
+        #
         Holding.includes(:inventory).includes(:item).all.each do |h|
           all_items[h.item.name] ||= {}
           all_items[h.item.name][h.inventory.name] = h.quantity

--- a/app/admin/donation.rb
+++ b/app/admin/donation.rb
@@ -33,14 +33,14 @@ ActiveAdmin.register Donation do
   member_action :add_item_from_barcode, method: :post do
     donation=Donation.find(params[:id])
     barcode_item = BarcodeItem.includes(:item).find_by_value(params[:container][:value])
-    
+
     unless barcode_item.present?
-      redirect_to new_barcode_item_path(value: params[:container][:value], return_to_donation_id: params[:id]) and return 
+      redirect_to new_barcode_item_path(value: params[:container][:value], return_to_donation_id: params[:id]) and return
     end
 
     donation.track(barcode_item.item, barcode_item.quantity)
     redirect_to donation_path(params[:id], from:"barcode")
-  end  
+  end
 
   member_action :complete, method: :put do
     donation = Donation.find(params[:id])
@@ -106,30 +106,43 @@ end
         nil
       end
     end
+
     unless donation.completed == true
-      panel "Add Item" do
-        form_for :container, { :url => add_item_donation_path } do |f|
-          div do
-            f.label :item
-            f.select("item_id", Item.all.collect { |i| [i.name, i.id] } )
-          end
-          div do
-            f.label :quantity
-            f.text_field :quantity
-          end
-            f.submit
+      form_for :container, { :url => add_item_donation_path } do |f|
+        fieldset class: "inputs" do
+          legend { span "Add Item" }
+          ol do
+            li class: "select input" do
+              f.label :item, class: "label"
+              f.select("item_id", Item.all.collect { |i| [i.name, i.id] } )
+            end
+            li class: "input" do
+              f.label :quantity
+              f.text_field :quantity
+            end
+            li do
+              f.submit
+            end
           end
         end
       end
 
-      panel "Add Item in From Barcode" do
-        form_for :container, { url: add_item_from_barcode_donation_path } do |f|
-          div do
-            f.label "Click here and scan barcode"
-            f.text_field :value, autofocus: (params[:from].present? && params[:from] == "barcode")
+      form_for :container, { url: add_item_from_barcode_donation_path } do |f|
+        fieldset class: "inputs" do
+          legend do
+            span "Add Item in From Barcode"
           end
-          f.submit
+          ol do
+            li do
+              f.label "Click here and scan barcode", for: "container_value", class: "label"
+              f.text_field :value, autofocus: (params[:from].present? && params[:from] == "barcode")
+            end
+            li do
+              f.submit
+            end
+          end
         end
       end
     end
+  end
 end


### PR DESCRIPTION
ActiveAdmin uses Formtastic to build and style their forms, which uses a specific set of markup elements and classes to provide a consistent look and feel. This updates the elements of a few custom forms (inventory filter, donation add items) so their labels and control sizes match all of the other forms.

I implemented these changes manually, however there should be an easier way to leverage Formtastic's form builder objects. I tried to use `#semantic_form_for` along with `#inputs` and `#input` helper methods but the elements weren't rendering like they were supposed to. If anyone wants to build on top of this to leverage Formtastic's shorthand, that would be great. 
