### PR TITLE
Fixes inventory count totals on dashboard table

### DIFF
--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -3,7 +3,7 @@ module DashboardHelper
 	def diaper_drives_total(start_date=default_start_date, end_date=default_end_date)
 		Donation.where(source: "Diaper Drive").where("created_at >= ? AND created_at <= ?", start_date, end_date)
 	end
-	
+
 	def diaper_totals_by_source(source, start_date=default_start_date, end_date=default_end_date)
 		donations = Donation.where(source: source).where("created_at >= ? AND created_at <= ?", start_date, end_date)
 		total = 0
@@ -12,7 +12,7 @@ module DashboardHelper
 		end
 		total
 	end
-	
+
 	def diaper_totals(start_date=default_start_date, end_date=default_end_date)
 		sources = {"Diaper Drive" => 0, "Purchased Supplies" => 0, "Donation Pickup Location" => 0}
 		sources.each do |key, value|
@@ -20,7 +20,7 @@ module DashboardHelper
 		end
 		sources
 	end
-	
+
 	def dropoff_totals_by_location(location, start_date=default_start_date, end_date=default_end_date)
 		l = DropoffLocation.find_by(name: location)
 		donations = Donation.where(dropoff_location: l).where("created_at >= ? AND created_at <= ?", start_date, end_date)
@@ -38,7 +38,7 @@ module DashboardHelper
 		end
 		locations
 	end
-	
+
 	def dropoff_totals(start_date=default_start_date, end_date=default_end_date)
 		locations_list = DropoffLocation.all
 		locations = locations_list.map { |u| [u.name, 0] }.to_h

--- a/app/views/inventories/_inventory_dashboard_summary.html.erb
+++ b/app/views/inventories/_inventory_dashboard_summary.html.erb
@@ -2,7 +2,7 @@
   <thead>
   	<tr>
   	  <th>Item</th>
-  	  <%= inventories.each do |i| %>
+  	  <% inventories.each do |i| %>
   	     <th><%= i %></th>
   	   <% end %>
   	</tr>
@@ -12,9 +12,9 @@
     <% items.each do |i,h| %>
     <tr>
       <td><%= i %></td>
-       
-      <% h.each do |qty| %>
-      <td><%= qty[0]  %><%= qty[1] || 0 %></td>
+
+      <% inventories.each do |i| %>
+        <td><%= h[i] %></td>
       <% end %>
     </tr>
     <% end %>


### PR DESCRIPTION
Queries Items in inventory, grouping by item, inventory, and summing up quantity (to account for possible duplicates). Then the data is restructured to be rendered in the inventory dashboard summary partial. This also optimizes the number of loops it takes to build the data.

However there is a small cost of looping over the inventories array multiple times during rendering to pull the data out of items hash. Maybe there is room for improvement there.

This is related to @armahillo's comment in issue #37 
