### PR TITLE
Adding JS confirm when closing donation. Referencing #40.

### DIFF
--- a/app/admin/donation.rb
+++ b/app/admin/donation.rb
@@ -62,7 +62,7 @@ ActiveAdmin.register Donation do
 
 action_item only: :show do
   if donation.completed == false
-    link_to "Complete donation", complete_donation_path(donation.id), method: :put
+    link_to "Complete donation", complete_donation_path(donation.id), method: :put, data: { confirm: "Are you sure you would like to complete this donation? This action cannot be reversed!" }
   end
 end
 


### PR DESCRIPTION
This references the discussion in issue #40. This adds a JS confirm alert that displays to the user that completing a donation is irreversible, and prompts the user if they would like to continue.

Let me know if you would like me to change the text of the alert or the approach I took to adding it.
