### PR TITLE
Dashboard snapshot

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -27,6 +27,26 @@ ActiveAdmin.register_page "Dashboard" do
   end
 
   content title: proc{ I18n.t("active_admin.dashboard") } do
+    if !params[:start_date].blank?
+      start = DateTime.strptime(params[:start_date], "%Y-%m-%d").beginning_of_day
+    else
+      start = default_start_date
+    end
+    if !params[:end_date].blank?
+      date_end = DateTime.strptime(params[:end_date], "%Y-%m-%d").end_of_day
+    else
+      date_end = default_end_date
+    end
+    panel "Snapshot for #{start.strftime('%D')} - #{date_end.strftime('%D')}" do
+      columns do
+        column do
+          render partial: 'dashboard/snapshot', locals: { :type => "Donated", data: container_quantity_by_type("Donation", start, date_end) }
+        end
+        column do
+          render partial: 'dashboard/snapshot', locals: { :type => "Ticketed", data: container_quantity_by_type("Ticket", start, date_end) }
+        end
+      end
+    end
     columns do
       column do
         inventories = Inventory.all.collect { |i| i.name }
@@ -49,12 +69,6 @@ ActiveAdmin.register_page "Dashboard" do
         end
       end
       column do
-        if !params[:start_date].blank?
-          start = DateTime.strptime(params[:start_date], "%Y-%m-%d").beginning_of_day
-        end
-        if !params[:end_date].blank?
-          date_end = DateTime.strptime(params[:end_date], "%Y-%m-%d").end_of_day
-        end
         panel "Donation Totals" do
           para do
             render partial: 'donation_stats', :locals => {:start_date => start, :end_date => date_end }

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -17,3 +17,18 @@ $primary-color: #CC1E2F !default;
 // For example, to change the default status-tag color:
 //
 //   .status_tag { background: #6090DB; }
+
+// Snapshot styles
+.snapshot {
+	color: #fff;
+	padding: 8px 16px;
+	border-radius: 8px;
+	text-align: center;
+	font-size: 24px;
+}
+#Donated {
+	background-color: #f44336;
+}
+#Ticketed {
+	background-color: #69E85D;
+}

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -28,6 +28,10 @@ module DashboardHelper
 		result
 	end
 
+	def container_quantity_by_type(type, start_date=send(:default_start_date), end_date=send(:default_end_date))
+		Container.where(itemizable_type: type).where(created_at: start_date..end_date).sum(:quantity)
+	end
+
 	def default_start_date
 		DateTime.now - 1.year
 	end

--- a/app/views/dashboard/_snapshot.html.erb
+++ b/app/views/dashboard/_snapshot.html.erb
@@ -1,0 +1,3 @@
+<div class="snapshot" id="<%= type %>">
+	<%= data %> Items <%= type %>
+</div>

--- a/config/database.yml
+++ b/config/database.yml
@@ -14,7 +14,7 @@ default: &default
   pool: 5
   adapter: postgresql
   host: localhost
-  username: tmobaird
+  username: kwalters
 
 development: &development
   <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -14,7 +14,7 @@ default: &default
   pool: 5
   adapter: postgresql
   host: localhost
-  username: kwalters
+  username: tmobaird
 
 development: &development
   <<: *default

--- a/spec/helpers/dashboard_helper_spec.rb
+++ b/spec/helpers/dashboard_helper_spec.rb
@@ -88,4 +88,16 @@ RSpec.describe DashboardHelper, type: :helper do
 			expect(result.last[:data]).to eq({ item.name => 300 })
 		end
 	end
+	describe ".container_quantity_by_type" do
+		it "returns 1000" do
+			i = FactoryGirl.create(:inventory, name: "Thomas's inventory")
+			d = FactoryGirl.create(:donation)
+			item = FactoryGirl.create(:item)
+			c = FactoryGirl.create(:container, quantity: 1000, item: item)
+			d.containers << c
+			d.save
+			result = container_quantity_by_type("Donation")
+			expect(result).to eq(1533)
+		end
+	end
 end


### PR DESCRIPTION
Can someone take a look at this when they get a chance? 

This references issue #53. Rachel said she would like a "snapshot" type display on the dashboard and posted some screenshots of what they currently look like now. This PR adds badge-like elements to a new snapshot panel on the dashboard page which will display the total items donated and total items ticketed for a given date range. This snapshot panel is still in progress, but I think these two stats are a good start.

Works on the front end, and all specs pass, but just need an extra eye and any suggestions on how I've been going about this.
