### PR TITLE
Cleanup dashboard snapshot

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -46,6 +46,9 @@ ActiveAdmin.register_page "Dashboard" do
           render partial: 'dashboard/snapshot', locals: { :type => "Ticketed", data: container_quantity_by_type("Ticket", start, date_end) }
         end
       end
+      div do
+        render partial: 'metrics/inventory_charts', locals: {  }
+      end
     end
     columns do
       column do
@@ -62,10 +65,6 @@ ActiveAdmin.register_page "Dashboard" do
         end
         panel "Inventory Summary" do
           render partial: "inventories/inventory_dashboard_summary", object: all_items, as: :items, locals: { inventories: inventories }
-        end
-
-        panel "Inventory Charts" do
-          render partial: 'metrics/inventory_charts', locals: {  }
         end
       end
       column do

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -28,8 +28,26 @@ module DashboardHelper
 		result
 	end
 
+	def ticket_totals_by_inventory(start_date=send(:default_start_date), end_date=send(:default_end_date))
+		Ticket.joins(:containers)
+			.includes(:containers)
+			.where(created_at: start_date..end_date)
+			.group(:inventory_id)
+			.sum(:quantity)
+	end
+
+	def ticket_totals_by_partner(start_date=send(:default_start_date), end_date=send(:default_end_date))
+		Ticket.joins(:containers)
+			.includes(:containers)
+			.where(created_at: start_date..end_date)
+			.group(:partner_id)
+			.sum(:quantity)
+	end
+
 	def container_quantity_by_type(type, start_date=send(:default_start_date), end_date=send(:default_end_date))
-		Container.where(itemizable_type: type).where(created_at: start_date..end_date).sum(:quantity)
+		Container.where(itemizable_type: type)
+			.where(created_at: start_date..end_date)
+			.sum(:quantity)
 	end
 
 	def default_start_date

--- a/app/views/active_admin/page/_ticket_stats.html.erb
+++ b/app/views/active_admin/page/_ticket_stats.html.erb
@@ -1,11 +1,27 @@
 <% start_date = start_date.blank? ? default_start_date : start_date %>
 <% end_date = end_date.blank? ? default_end_date : end_date %>
 <h3><%= "Ticket Totals for #{start_date.strftime('%D')} - #{end_date.strftime('%D')}" %></h3>
-<h5>Totals Items Distributed By Source:</h5>
+<h5>Totals Items Distributed By Inventory Location:</h5>
 <ul>
-  <li>No stats to display yet</li>
+  <% if start_date.blank? || end_date.blank?
+ 	  totals = ticket_totals_by_inventory
+  else
+    totals = ticket_totals_by_inventory(start_date, end_date)
+  end
+
+  totals.each do |source, total| %>
+    <li><%= "#{Inventory.find(source).name}: #{total}" %></li>
+  <% end %>
 </ul>
-<h5>Totals Items Distributed By Location:</h5>
+<h5>Totals Items Distributed To Partner:</h5>
 <ul>
-	<li>No stats to display yet</li>
+	<% if start_date.blank? || end_date.blank?
+ 	  totals = ticket_totals_by_partner
+  else
+    totals = ticket_totals_by_partner(start_date, end_date)
+  end
+
+  totals.each do |source, total| %>
+    <li><%= "#{Partner.find(source).name}: #{total}" %></li>
+  <% end %>
 </ul>

--- a/app/views/metrics/_inventory_charts.html.erb
+++ b/app/views/metrics/_inventory_charts.html.erb
@@ -1,7 +1,5 @@
 <%= javascript_include_tag "https://www.google.com/jsapi" %>
 
-<p>
 	<h4>Current Item Totals</h4>
 	<% data = item_totals_for_inventories %>
 	<%= bar_chart(data, stacked: true) %>
-</p>

--- a/spec/helpers/dashboard_helper_spec.rb
+++ b/spec/helpers/dashboard_helper_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe DashboardHelper, type: :helper do
 	end
 	describe ".item_totals_for_inventories" do
 		it "returns an array of hashes" do
+			FactoryGirl.create :holding
 			result = item_totals_for_inventories
 			expect(result).to be_a Array
 			expect(result.first).to be_a Hash
@@ -97,7 +98,77 @@ RSpec.describe DashboardHelper, type: :helper do
 			d.containers << c
 			d.save
 			result = container_quantity_by_type("Donation")
-			expect(result).to eq(1533)
+			expect(result).to eq(1000)
+		end
+	end
+	describe ".ticket_totals_by_inventory" do
+		it "returns hash" do
+			result = ticket_totals_by_inventory
+			expect(result).to be_a Hash
+		end
+		it "returns hash { inventory_id => 1000 }" do
+			allow(helper).to receive(:default_start_date).and_return(DateTime.now)
+			allow(helper).to receive(:default_end_date).and_return(DateTime.now + 1.day)
+			item = FactoryGirl.create(:item)
+			inventory = FactoryGirl.create(:inventory, name: "Thomas's inventory")
+			inventory.holdings << FactoryGirl.create(:holding, quantity: 1000)
+			inventory.save
+			t = FactoryGirl.create(:ticket, inventory: inventory)
+			t.containers << FactoryGirl.create(:container, quantity: 1000, item: item)
+			t.save
+			result = ticket_totals_by_inventory
+			expect(result).to eq({ inventory.id => 1000 })
+		end
+		it "returns hash { inventory_id => 2000 }" do
+			allow(helper).to receive(:default_start_date).and_return(DateTime.now)
+			allow(helper).to receive(:default_end_date).and_return(DateTime.now + 1.day)
+			item = FactoryGirl.create(:item)
+			inventory = FactoryGirl.create(:inventory, name: "Thomas's inventory")
+			inventory.holdings << FactoryGirl.create(:holding, quantity: 1000, inventory: inventory)
+			inventory.save
+			2.times do
+				t = FactoryGirl.create(:ticket, inventory: inventory)
+				t.containers << FactoryGirl.create(:container, quantity: 1000, item: item, itemizable_id: t.id, itemizable_type: "Ticket")
+				t.save
+			end
+			result = ticket_totals_by_inventory
+			expect(result).to eq({ inventory.id => 2000 })
+		end
+	end
+	describe ".ticket_totals_by_partner" do
+		it "returns hash" do
+			result = ticket_totals_by_partner
+			expect(result).to be_a Hash
+		end
+		it "returns hash { partner_id => 1000 }" do
+			allow(helper).to receive(:default_start_date).and_return(DateTime.now)
+			allow(helper).to receive(:default_end_date).and_return(DateTime.now + 1.day)
+			p = FactoryGirl.create :partner
+			item = FactoryGirl.create(:item)
+			inventory = FactoryGirl.create(:inventory, name: "Thomas's inventory")
+			inventory.holdings << FactoryGirl.create(:holding, quantity: 1000)
+			inventory.save
+			t = FactoryGirl.create(:ticket, inventory: inventory, partner: p)
+			t.containers << FactoryGirl.create(:container, quantity: 1000, item: item)
+			t.save
+			result = ticket_totals_by_partner
+			expect(result).to eq({ p.id => 1000 })
+		end
+		it "returns hash { partner_id => 2000 }" do
+			allow(helper).to receive(:default_start_date).and_return(DateTime.now)
+			allow(helper).to receive(:default_end_date).and_return(DateTime.now + 1.day)
+			p = FactoryGirl.create :partner
+			item = FactoryGirl.create(:item)
+			inventory = FactoryGirl.create(:inventory, name: "Thomas's inventory")
+			inventory.holdings << FactoryGirl.create(:holding, quantity: 1000, inventory: inventory)
+			inventory.save
+			2.times do
+				t = FactoryGirl.create(:ticket, inventory: inventory, partner: p)
+				t.containers << FactoryGirl.create(:container, quantity: 1000, item: item, itemizable_id: t.id, itemizable_type: "Ticket")
+				t.save
+			end
+			result = ticket_totals_by_inventory
+			expect(result).to eq({ inventory.id => 2000 })
 		end
 	end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,7 +34,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
@@ -52,11 +52,16 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
 
   config.before(:suite) do
-    DatabaseCleaner.strategy = :transaction
+    FactoryGirl.lint
     DatabaseCleaner.clean_with(:truncation)
+    DatabaseCleaner.strategy = :transaction
   end
 
   config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
     DatabaseCleaner.clean
   end
 
@@ -66,8 +71,4 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.include FactoryGirl::Syntax::Methods
-
-  config.before(:suite) do
-    FactoryGirl.lint
-  end
 end


### PR DESCRIPTION
This PR contains a few different things. First, I moved the Items in Inventory chart to be included in the snapshot panel. It was originally in it's own panel on the bottom of the page, but I moved it to the snapshot panel because I felt it is one of the more critical charts. 

Second, I **FINALLY** added the ticket stats for the dashboard and the specs that go along with it. I added helpers in the dashboard_helper.rb to help generate these stats. I also added specs for these and they all pass locally for me.

Lastly, I edited the DatabaseCleaner strategy. When I was writing my specs for the dashboard helpers I was seeing some weird behavior with Inventories appearing within the db that should not have been there, and it looked like some of the tables weren't getting cleaned after some specs ran. I changed the strategy to:

``` ruby
config.before(:suite) do
  FactoryGirl.lint
  DatabaseCleaner.clean_with(:truncation)
  DatabaseCleaner.strategy = :transaction
end

config.before(:each) do
  DatabaseCleaner.start
end

config.after(:each) do
  DatabaseCleaner.clean
end
```

So that we lint and clear the db before the suite. Then the transactions will be tracked before and cleaned after each example. All the tests pass locally after these changes!

Feel free to let me know if there are any problems with these changes! 👍 
