### PR TITLE
Fix Travis build status button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # README
 
-{<img src="https://travis-ci.org/rubyforgood/pdx_diaper.svg?branch=master" alt="Build Status" />}[https://travis-ci.org/rubyforgood/pdx_diaper]
+[![Build Status](https://travis-ci.org/rubyforgood/pdx_diaper.svg?branch=master)](https://travis-ci.org/rubyforgood/pdx_diaper)
 
 ## Ruby Version
 This app uses Ruby version 2.3.0, indicated in `/.ruby-version`, which will be auto-selected if you use a Ruby versioning manager like `rvm` or `rbenv`.


### PR DESCRIPTION
The Travis build status button was using invalid markdown, and as a result the
link didn't work and some of the markup was visible. This PR fixes it to use
valid markdown.

**Before:**
![broken button](https://cloud.githubusercontent.com/assets/814638/17940386/cf5958b2-69fc-11e6-8399-0ed74a74badc.png)

**After:**
![fixed button](https://cloud.githubusercontent.com/assets/814638/17940393/d90bed0c-69fc-11e6-9a15-3dbdacfa9a99.png)
