### PR TITLE
Fixes and edge case with the transfer/ticket functionality

### DIFF
--- a/app/admin/transfer.rb
+++ b/app/admin/transfer.rb
@@ -46,8 +46,7 @@ ActiveAdmin.register Transfer do
     column :id do |ticket|
       link_to ticket.id, ticket
     end
-    column :from
-    column :to
+
     column :number_of_items do |ticket|
       ticket.containers.count
     end
@@ -73,9 +72,13 @@ ActiveAdmin.register Transfer do
 
   show do |ticket|
     attributes_table do
-      row :to
+      row('Sending Facility') do |row|
+        link_to row.from.name, inventory_path(row.from)
+      end
+      row('Receiving Facility') do |row|
+        link_to row.to.name, inventory_path(row.to)
+      end
       row :created_at
-      row :from
       row :comment
     end
     columns do

--- a/app/admin/transfer.rb
+++ b/app/admin/transfer.rb
@@ -1,10 +1,6 @@
 ActiveAdmin.register Transfer do
   actions :all, except: [:edit, :update, :destroy]
 
-  action_item :reclaim, only: :show do
-    link_to "Reclaim", reclaim_transfer_path(transfer), method: :put
-  end
-
   filter :inventory
   filter :partner
   filter :items

--- a/app/models/holding.rb
+++ b/app/models/holding.rb
@@ -11,6 +11,8 @@
 #
 
 class Holding < ActiveRecord::Base
+  after_initialize :set_quantity
+
   belongs_to :inventory
   belongs_to :item
 
@@ -18,4 +20,8 @@ class Holding < ActiveRecord::Base
   validates :inventory_id, presence: true
   validates :item_id, presence: true
   validates :quantity, numericality: { only_integer: true, greater_than_or_equal_to: 0}
+
+  def set_quantity
+  	self.quantity ||= 0
+  end
 end

--- a/app/models/inventory.rb
+++ b/app/models/inventory.rb
@@ -79,7 +79,6 @@ class Inventory < ActiveRecord::Base
       next if holding.nil? || holding.quantity == 0
       if holding.quantity >= container.quantity
         updated_quantities[holding.id] = (updated_quantities[holding.id] || holding.quantity) - container.quantity
-        # updated_quantities[new_holding.id] = new_holding.quantity + container.quantity
         updated_quantities[new_holding.id] = (updated_quantities[new_holding.id] || 
           new_holding.quantity) + container.quantity
       else

--- a/app/models/inventory.rb
+++ b/app/models/inventory.rb
@@ -50,7 +50,7 @@ class Inventory < ActiveRecord::Base
       holding = self.holdings.find_by(item: container.item)
       next if holding.nil? || holding.quantity == 0
       if holding.quantity >= container.quantity
-        updated_quantities[holding.id] = holding.quantity - container.quantity
+        updated_quantities[holding.id] = (updated_quantities[holding.id] || holding.quantity) - container.quantity
       else
         insufficient_items << {
           item_id: container.item.id,
@@ -78,8 +78,10 @@ class Inventory < ActiveRecord::Base
       new_holding = transfer.to.holdings.find_or_create_by(item: container.item)
       next if holding.nil? || holding.quantity == 0
       if holding.quantity >= container.quantity
-        updated_quantities[holding.id] = holding.quantity - container.quantity
-        updated_quantities[new_holding.id] = new_holding.quantity + container.quantity
+        updated_quantities[holding.id] = (updated_quantities[holding.id] || holding.quantity) - container.quantity
+        # updated_quantities[new_holding.id] = new_holding.quantity + container.quantity
+        updated_quantities[new_holding.id] = (updated_quantities[new_holding.id] || 
+          new_holding.quantity) + container.quantity
       else
         insufficient_items << {
           item_id: container.item.id,


### PR DESCRIPTION
There was an error with an edge case in both tickets and transfers if a user attempted to transfer the the same item twice in the same ticket or transfer it would only record the last container value.

So attempting to transfer two batches of diapers(newborn) with quantities 100 and 200 would result in only 200 being transfered/ticketed.

This was an error in the original ticket logic that I inadvertently brought into the transfer logic.
